### PR TITLE
Fix documentation drift: config command, license link, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - REST API for exposing activity data via HTTP endpoints
 - `/at average` command for viewing average daily activity
 - `/at top` command algorithm optimized to O(n log n)
-- Discord webhook notification support
 - Player activity ranking display in `/at info`
 - Visual bar indicators in command output

--- a/REST_API.md
+++ b/REST_API.md
@@ -12,8 +12,8 @@ restApiPort: 8080     # Port number for the API server
 ```
 
 You can also configure these settings in-game using the `/at config` command:
-- `/at config restApiEnabled true`
-- `/at config restApiPort 8080`
+- `/at config set restApiEnabled true`
+- `/at config set restApiPort 8080`
 
 ## API Endpoints
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10,7 +10,7 @@ info:
     url: https://github.com/Dans-Plugins/Activity-Tracker
   license:
     name: GPL-3.0
-    url: https://github.com/Dans-Plugins/Activity-Tracker/blob/master/LICENSE
+    url: https://github.com/Dans-Plugins/Activity-Tracker/blob/main/LICENSE
 
 servers:
   - url: http://localhost:8080


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

Stage A documentation-accuracy sweep (repo-wide, not tied to a specific issue). Three drift items found by verifying each doc claim against the actual source:

- `REST_API.md` documented `/at config restApiEnabled true` / `/at config restApiPort 8080`, but `ConfigCommand.java` requires a `set` subcommand — the actual usage is `/at config set <option> <value>`, as correctly documented in `COMMANDS.md` and `USER_GUIDE.md`. Fixed the two REST_API.md examples to match.
- `openapi.yaml`'s license URL pointed at `blob/master/LICENSE`. The repo's only branch is `main` (confirmed via `git ls-remote`) — `master` doesn't exist, so the link was dead. Fixed to `blob/main/LICENSE`.
- `CHANGELOG.md` listed "Discord webhook notification support" under the released `[1.3.0]` section, but that feature exists only in an open, unmerged draft PR (#77) — there is no `DiscordWebhookService` on `main`. Removed the premature line.

REST API doc/code/spec parity was otherwise fully verified (all 6 endpoints and every response field checked against `RestApiService.java` and its response DTOs — no other drift found). `README.md`'s Java-8 badge matches `pom.xml`, and `COMMANDS.md` command signatures match their handler classes.

## Test plan
- [x] `mvn compile` — clean
- [x] `mvn test` — 33 tests pass (one run showed a wall-clock timing flake in `TopRecordsAlgorithmTest.testGetTopRecords_ComplexityValidation`, unrelated to this change; re-ran and it passed — pre-existing timing-sensitivity in that performance assertion, not touched by this PR)
- Docs-only change, no `algorithms/TopRecordsAlgorithm.java` modification, so the `Simple CI` anchor is not applicable to this diff (UNVERIFIED-not-applicable)

Closes: none — this is a proactive sweep, not tied to a tracked issue.

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
