### PR TITLE
Allow /at top to accept an optional number of players

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- Optional number argument for `/at top` (e.g. `/at top 25`), defaulting to 10 and capped at 100
 - DPC conventions alignment: CONTRIBUTING.md, USER_GUIDE.md, COMMANDS.md, CONFIG.md, CHANGELOG.md
 - CI workflow (build.yml) following DPC conventions
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -33,11 +33,14 @@ All commands use the base command `/at` (or `/activitytracker`).
 **Example:** `/at average Notch 14`  
 **Defaults:** Current player, 7 days
 
-### /at top
+### /at top [number]
 
-**Description:** Displays the top 10 most active players by total hours played, with visual bar indicators.  
+**Description:** Displays the most active players by total hours played, with visual bar indicators.  
 **Permission:** `at.top`  
-**Usage:** `/at top`
+**Usage:** `/at top` or `/at top <number>`  
+**Example:** `/at top 25`  
+**Defaults:** 10 players  
+**Limits:** The number must be between 1 and 100
 
 ### /at stats
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -24,7 +24,7 @@ Run `/at info <playerName>` to see the activity record for a specific player.
 
 ### Checking the Leaderboard
 
-Run `/at top` to see the top 10 most active players by total hours played.
+Run `/at top` to see the top 10 most active players by total hours played, or `/at top <number>` to see a different number of players (up to 100).
 
 ### Viewing Server-Wide Statistics
 

--- a/src/main/java/dansplugins/activitytracker/commands/HelpCommand.java
+++ b/src/main/java/dansplugins/activitytracker/commands/HelpCommand.java
@@ -27,6 +27,7 @@ public class HelpCommand extends AbstractPluginCommand {
         sender.sendMessage(ChatColor.GOLD + "│ " + ChatColor.AQUA + "/at info (playerName) " + ChatColor.GRAY + "- View a player's activity record.");
         sender.sendMessage(ChatColor.GOLD + "│ " + ChatColor.AQUA + "/at list " + ChatColor.GRAY + "- View the 10 most recent sessions (admin only).");
         sender.sendMessage(ChatColor.GOLD + "│ " + ChatColor.AQUA + "/at top " + ChatColor.GRAY + "- View the most active players.");
+        sender.sendMessage(ChatColor.GOLD + "│ " + ChatColor.AQUA + "/at top (number) " + ChatColor.GRAY + "- View a set number of active players.");
         sender.sendMessage(ChatColor.GOLD + "│ " + ChatColor.AQUA + "/at stats " + ChatColor.GRAY + "- View activity stats for the server.");
         sender.sendMessage(ChatColor.GOLD + "│ " + ChatColor.AQUA + "/at average [player] [days] " + ChatColor.GRAY + "- Avg daily activity (default: 7 days).");
         sender.sendMessage(ChatColor.GOLD + "│ " + ChatColor.AQUA + "/at config " + ChatColor.GRAY + "- Show or set config options.");

--- a/src/main/java/dansplugins/activitytracker/commands/TopCommand.java
+++ b/src/main/java/dansplugins/activitytracker/commands/TopCommand.java
@@ -16,6 +16,8 @@ import preponderous.ponder.minecraft.bukkit.tools.UUIDChecker;
  */
 public class TopCommand extends AbstractPluginCommand {
     private final ActivityRecordService activityRecordService;
+    private static final int DEFAULT_COUNT = 10;
+    private static final int MAX_COUNT = 100;
 
     public TopCommand(ActivityRecordService activityRecordService) {
         super(new ArrayList<>(Arrays.asList("top")), new ArrayList<>(Arrays.asList("at.top")));
@@ -24,7 +26,11 @@ public class TopCommand extends AbstractPluginCommand {
 
     @Override
     public boolean execute(CommandSender sender) {
-        ArrayList<ActivityRecord> records = activityRecordService.getTopTenRecords();
+        return displayTopRecords(sender, DEFAULT_COUNT);
+    }
+
+    private boolean displayTopRecords(CommandSender sender, int count) {
+        ArrayList<ActivityRecord> records = activityRecordService.getTopRecords(count);
 
         sender.sendMessage("");
         sender.sendMessage(ChatColor.GOLD + "┌─ " + ChatColor.YELLOW + "" + ChatColor.BOLD + "Activity Tracker" +
@@ -44,7 +50,7 @@ public class TopCommand extends AbstractPluginCommand {
             }
         }
         
-        int count = 1;
+        int rank = 1;
         UUIDChecker uuidChecker = new UUIDChecker();
         for (ActivityRecord record : records) {
             if (record == null) {
@@ -59,11 +65,11 @@ public class TopCommand extends AbstractPluginCommand {
                 }
 
                 String bar = createBar(record.getTotalHoursSpent(), maxHours > 0 ? maxHours : 1);
-                sender.sendMessage(ChatColor.GOLD + "│ " + ChatColor.AQUA + "#" + count + " " +
+                sender.sendMessage(ChatColor.GOLD + "│ " + ChatColor.AQUA + "#" + rank + " " +
                                   ChatColor.WHITE + playerName + " " +
                                   ChatColor.GREEN + String.format("%.2f", record.getTotalHoursSpent()) + "h " +
                                   ChatColor.DARK_GRAY + bar);
-                count++;
+                rank++;
             } catch (Exception e) {
                 continue;
             }
@@ -85,6 +91,28 @@ public class TopCommand extends AbstractPluginCommand {
 
     @Override
     public boolean execute(CommandSender sender, String[] args) {
-        return execute(sender);
+        if (args.length == 0) {
+            return execute(sender);
+        }
+
+        int count;
+        try {
+            count = Integer.parseInt(args[0]);
+        } catch (NumberFormatException e) {
+            sender.sendMessage(ChatColor.RED + "Invalid number of players. Usage: /at top [number]");
+            return false;
+        }
+
+        if (count <= 0) {
+            sender.sendMessage(ChatColor.RED + "The number of players must be a positive number.");
+            return false;
+        }
+
+        if (count > MAX_COUNT) {
+            sender.sendMessage(ChatColor.RED + "You can view at most " + MAX_COUNT + " players at a time.");
+            return false;
+        }
+
+        return displayTopRecords(sender, count);
     }
 }

--- a/src/main/java/dansplugins/activitytracker/services/ActivityRecordService.java
+++ b/src/main/java/dansplugins/activitytracker/services/ActivityRecordService.java
@@ -46,23 +46,33 @@ public class ActivityRecordService {
     }
 
     public ArrayList<ActivityRecord> getTopTenRecords() {
+        return getTopRecords(10);
+    }
+
+    /**
+     * Get the top records sorted by total hours played (descending)
+     * @param count The number of records to return
+     * @return List of the top records, or fewer if less than count records exist
+     * @throws IllegalArgumentException if count is negative
+     */
+    public ArrayList<ActivityRecord> getTopRecords(int count) {
         ArrayList<ActivityRecord> allRecords = new ArrayList<>(persistentData.getActivityRecords());
-        
+
         // Wrap records in adapters for the generic algorithm
         List<ActivityRecordAdapter> adapters = new ArrayList<>();
         for (ActivityRecord record : allRecords) {
             adapters.add(new ActivityRecordAdapter(record));
         }
-        
+
         // Use the generic algorithm
-        List<ActivityRecordAdapter> topAdapters = topRecordsAlgorithm.getTopTenRecords(adapters);
-        
+        List<ActivityRecordAdapter> topAdapters = topRecordsAlgorithm.getTopRecords(adapters, count);
+
         // Extract the original records
         ArrayList<ActivityRecord> result = new ArrayList<>();
         for (ActivityRecordAdapter adapter : topAdapters) {
             result.add(adapter.getRecord());
         }
-        
+
         return result;
     }
 

--- a/src/test/java/dansplugins/activitytracker/commands/TopCommandTest.java
+++ b/src/test/java/dansplugins/activitytracker/commands/TopCommandTest.java
@@ -1,0 +1,112 @@
+package dansplugins.activitytracker.commands;
+
+import org.bukkit.command.CommandSender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import dansplugins.activitytracker.objects.ActivityRecord;
+import dansplugins.activitytracker.services.ActivityRecordService;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for TopCommand.
+ * Covers the optional number argument added to /at top.
+ *
+ * @author Daniel McCoy Stephenson
+ */
+class TopCommandTest {
+
+    private ActivityRecordService activityRecordService;
+    private CommandSender sender;
+    private TopCommand topCommand;
+
+    @BeforeEach
+    void setUp() {
+        activityRecordService = mock(ActivityRecordService.class);
+        sender = mock(CommandSender.class);
+        when(activityRecordService.getTopRecords(anyInt())).thenReturn(new ArrayList<ActivityRecord>());
+        topCommand = new TopCommand(activityRecordService);
+    }
+
+    @Test
+    @DisplayName("Should request ten records when no argument is given")
+    void testExecute_NoArguments_UsesDefaultOfTen() {
+        topCommand.execute(sender, new String[]{});
+
+        verify(activityRecordService).getTopRecords(10);
+    }
+
+    @Test
+    @DisplayName("Should request ten records when the sender-only overload is used")
+    void testExecute_SenderOnly_UsesDefaultOfTen() {
+        topCommand.execute(sender);
+
+        verify(activityRecordService).getTopRecords(10);
+    }
+
+    @Test
+    @DisplayName("Should request the requested number of records when a valid number is given")
+    void testExecute_ValidNumber_UsesRequestedCount() {
+        topCommand.execute(sender, new String[]{"25"});
+
+        verify(activityRecordService).getTopRecords(25);
+    }
+
+    @Test
+    @DisplayName("Should accept the maximum allowed number of records")
+    void testExecute_MaximumNumber_UsesRequestedCount() {
+        topCommand.execute(sender, new String[]{"100"});
+
+        verify(activityRecordService).getTopRecords(100);
+    }
+
+    @Test
+    @DisplayName("Should reject a non-numeric argument")
+    void testExecute_NonNumericArgument_IsRejected() {
+        boolean result = topCommand.execute(sender, new String[]{"abc"});
+
+        assertFalse(result);
+        verify(sender).sendMessage(contains("Invalid number of players"));
+        verify(activityRecordService, never()).getTopRecords(anyInt());
+    }
+
+    @Test
+    @DisplayName("Should reject zero")
+    void testExecute_Zero_IsRejected() {
+        boolean result = topCommand.execute(sender, new String[]{"0"});
+
+        assertFalse(result);
+        verify(sender).sendMessage(contains("must be a positive number"));
+        verify(activityRecordService, never()).getTopRecords(anyInt());
+    }
+
+    @Test
+    @DisplayName("Should reject a negative number")
+    void testExecute_NegativeNumber_IsRejected() {
+        boolean result = topCommand.execute(sender, new String[]{"-5"});
+
+        assertFalse(result);
+        verify(sender).sendMessage(contains("must be a positive number"));
+        verify(activityRecordService, never()).getTopRecords(anyInt());
+    }
+
+    @Test
+    @DisplayName("Should reject a number above the maximum")
+    void testExecute_NumberAboveMaximum_IsRejected() {
+        boolean result = topCommand.execute(sender, new String[]{"101"});
+
+        assertFalse(result);
+        verify(sender).sendMessage(contains("at most 100 players"));
+        verify(activityRecordService, never()).getTopRecords(anyInt());
+    }
+}

--- a/src/test/java/dansplugins/activitytracker/services/ActivityRecordServiceTest.java
+++ b/src/test/java/dansplugins/activitytracker/services/ActivityRecordServiceTest.java
@@ -1,0 +1,112 @@
+package dansplugins.activitytracker.services;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.UUID;
+
+import dansplugins.activitytracker.data.PersistentData;
+import dansplugins.activitytracker.factories.ActivityRecordFactory;
+import dansplugins.activitytracker.objects.ActivityRecord;
+import dansplugins.activitytracker.objects.Session;
+import dansplugins.activitytracker.utils.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for ActivityRecordService.
+ * Covers the configurable record count used by /at top.
+ *
+ * @author Daniel McCoy Stephenson
+ */
+class ActivityRecordServiceTest {
+
+    private Logger logger;
+    private PersistentData persistentData;
+    private ActivityRecordService activityRecordService;
+
+    @BeforeEach
+    void setUp() {
+        logger = mock(Logger.class);
+        persistentData = new PersistentData(logger);
+        activityRecordService = new ActivityRecordService(persistentData, mock(ActivityRecordFactory.class), logger);
+    }
+
+    @Test
+    @DisplayName("Should return an empty list when no records exist")
+    void testGetTopRecords_NoRecords() {
+        ArrayList<ActivityRecord> result = activityRecordService.getTopRecords(5);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should return the requested number of records sorted by hours descending")
+    void testGetTopRecords_ReturnsRequestedCountInOrder() {
+        addRecordWithHours(1.0);
+        addRecordWithHours(5.0);
+        addRecordWithHours(3.0);
+        addRecordWithHours(9.0);
+
+        ArrayList<ActivityRecord> result = activityRecordService.getTopRecords(3);
+
+        assertEquals(3, result.size());
+        assertEquals(9.0, result.get(0).getTotalHoursSpent(), 0.001);
+        assertEquals(5.0, result.get(1).getTotalHoursSpent(), 0.001);
+        assertEquals(3.0, result.get(2).getTotalHoursSpent(), 0.001);
+    }
+
+    @Test
+    @DisplayName("Should return every record when fewer records exist than requested")
+    void testGetTopRecords_FewerRecordsThanRequested() {
+        addRecordWithHours(2.0);
+        addRecordWithHours(4.0);
+
+        ArrayList<ActivityRecord> result = activityRecordService.getTopRecords(25);
+
+        assertEquals(2, result.size());
+        assertEquals(4.0, result.get(0).getTotalHoursSpent(), 0.001);
+    }
+
+    @Test
+    @DisplayName("Should return an empty list when zero records are requested")
+    void testGetTopRecords_ZeroRequested() {
+        addRecordWithHours(2.0);
+
+        assertTrue(activityRecordService.getTopRecords(0).isEmpty());
+    }
+
+    @Test
+    @DisplayName("Should throw when a negative number of records is requested")
+    void testGetTopRecords_NegativeRequested() {
+        addRecordWithHours(2.0);
+
+        assertThrows(IllegalArgumentException.class, () -> activityRecordService.getTopRecords(-1));
+    }
+
+    @Test
+    @DisplayName("Should return at most ten records from getTopTenRecords")
+    void testGetTopTenRecords_LimitsToTen() {
+        for (int i = 0; i < 12; i++) {
+            addRecordWithHours(i);
+        }
+
+        ArrayList<ActivityRecord> result = activityRecordService.getTopTenRecords();
+
+        assertEquals(10, result.size());
+        assertEquals(11.0, result.get(0).getTotalHoursSpent(), 0.001);
+        assertEquals(2.0, result.get(9).getTotalHoursSpent(), 0.001);
+    }
+
+    private void addRecordWithHours(double hours) {
+        UUID playerUUID = UUID.randomUUID();
+        Session session = new Session(logger, 1, playerUUID);
+        session.setActive(false);
+        ActivityRecord record = new ActivityRecord(playerUUID, session);
+        record.setHoursSpent(hours);
+        persistentData.addRecord(record);
+    }
+}


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

- `/at top` now accepts an optional number argument (`/at top 25`); the default remains 10 and the maximum accepted value is 100, so a single command cannot flood chat with an unbounded leaderboard.
- `ActivityRecordService.getTopRecords(int count)` was added, and `getTopTenRecords()` now delegates to it. The existing REST leaderboard endpoint keeps calling `getTopTenRecords()`, so its behavior and documented response shape are unchanged.
- Argument validation follows the style already established by `/at average`: a non-numeric argument, zero or a negative number, and a number above 100 are each rejected with a red message and no leaderboard output.
- The in-game help output, `COMMANDS.md`, `USER_GUIDE.md` and `CHANGELOG.md` were updated to describe the new argument.

Closes #38

## Test plan

- [x] `mvn -B test` — 47 tests run, 0 failures (33 pre-existing plus 14 new).
- [x] `TopCommandTest` (new, JUnit 5): default of 10 with no argument and via the sender-only overload, the requested count for a valid argument, the boundary value 100, and rejection of `abc`, `0`, `-5` and `101` with the service never consulted.
- [x] `ActivityRecordServiceTest` (new, JUnit 5): ordering by hours descending, the requested count honored, fewer records than requested, zero requested, a negative count propagating `IllegalArgumentException` from the algorithm, and `getTopTenRecords()` still capping at 10.
- [ ] In-game smoke test on a Spigot server — not run in this environment; the plugin's Bukkit command path has no automated coverage.

## Notes on test scope

New tests were written against JUnit 5 deliberately: the JUnit 4 classes in this repository are not currently executed by Surefire, which is filed separately as #80. A timing-flaky assertion observed while investigating that is filed as #81, and a `CONTRIBUTING.md` reference to a non-existent `develop` branch is filed as #82. None of the three is addressed here, to keep this change scoped to #38 and out of `pom.xml`.

## Deferred this cycle

The remaining open issues were not picked up, for the reasons below:

- #47 — already in flight as draft PR #77 (authored by the Copilot coding agent); that PR was left untouched rather than adopted or closed, since its draft state signals its author is not finished with it.
- #43, #41, #40, #39 — the colored-names epic and its tasks form one multi-part feature that exceeds a single polish-sized PR.
- #45 — hourly precomputation of the top-ten list is a scheduler/persistence change, larger than this cycle's scope, and is best revisited after #38 since the command now takes a variable count.
- #54 — the issue body is empty, so what "total visits" should count (sessions, unique players, or logins) is not specified.
- #13 — a design question rather than an actionable change.

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).