### PR TITLE
Run the dormant JUnit 4 tests and let test failures fail CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - DPC conventions alignment: CONTRIBUTING.md, USER_GUIDE.md, COMMANDS.md, CONFIG.md, CHANGELOG.md
 - CI workflow (build.yml) following DPC conventions
 
+### Fixed
+- JUnit 4 test classes are now executed by Surefire (`junit-vintage-engine` added), raising the suite from 47 to 125 tests
+- Test failures now fail the CI build; the `ci-test` profile no longer sets `maven.test.failure.ignore`
+- `TopRecordsAlgorithmTest` complexity check now counts comparator invocations instead of measuring wall-clock time, removing a timing-related flake
+
 ## [1.3.0]
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,13 @@
             <version>${junit4.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- Vintage engine so the JUnit 4 tests above are run by the JUnit Platform provider -->
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- JUnit 5 for TopRecordsAlgorithm tests -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -205,10 +212,6 @@
                     <name>env.CI</name>
                 </property>
             </activation>
-            <properties>
-                <!-- Make external dependencies optional in CI -->
-                <maven.test.failure.ignore>true</maven.test.failure.ignore>
-            </properties>
             <dependencies>
                 <!-- Override problematic dependencies with stubs in CI -->
                 <dependency>

--- a/src/test/java/dansplugins/activitytracker/algorithms/TopRecordsAlgorithmTest.java
+++ b/src/test/java/dansplugins/activitytracker/algorithms/TopRecordsAlgorithmTest.java
@@ -388,29 +388,42 @@ class TopRecordsAlgorithmTest {
     @DisplayName("Should maintain O(n log n) complexity with increasing sizes")
     void testGetTopRecords_ComplexityValidation() {
         int[] sizes = {100, 500, 1000, 2000};
-        long[] times = new long[sizes.length];
-        
+        long[] comparisons = new long[sizes.length];
+
+        // Comparisons are counted rather than timed, so the result is deterministic
+        // and independent of JIT warm-up, GC and machine load.
         for (int i = 0; i < sizes.length; i++) {
-            List<MockScorable> records = createMockRecords(sizes[i]);
-            
-            long startTime = System.nanoTime();
-            List<MockScorable> result = algorithm.getTopRecords(records, 10);
-            long endTime = System.nanoTime();
-            
-            times[i] = endTime - startTime;
+            long[] scoreReads = new long[1];
+            List<CountingScorable> records = createCountingRecords(sizes[i], scoreReads);
+
+            scoreReads[0] = 0;
+            List<CountingScorable> result = algorithm.getTopRecords(records, 10);
+
+            // The comparator reads one score from each of the two records it compares.
+            comparisons[i] = scoreReads[0] / 2;
             assertEquals(10, result.size());
         }
-        
-        // Verify that time doesn't grow quadratically
-        // For O(n log n), time ratio should be roughly (n2/n1) * log(n2)/log(n1)
+
+        // A comparison sort with O(n log n) behaviour needs on the order of n * log2(n)
+        // comparisons on random input; a quadratic one needs on the order of n^2 / 2.
+        // The factor of two absorbs differences between JDK sort implementations while
+        // staying far below the quadratic count (4950 comparisons at n=100).
+        for (int i = 0; i < sizes.length; i++) {
+            double bound = 2 * sizes[i] * (Math.log(sizes[i]) / Math.log(2));
+            assertTrue(comparisons[i] <= bound,
+                "Comparison count suggests worse than O(n log n) for n=" + sizes[i] + ": "
+                    + comparisons[i] + " vs bound " + bound);
+        }
+
+        // Verify that the comparison count doesn't grow quadratically.
+        // For O(n log n), the ratio should be roughly (n2/n1) * log(n2)/log(n1).
         for (int i = 1; i < sizes.length; i++) {
             double sizeRatio = (double) sizes[i] / sizes[i-1];
-            double expectedTimeRatio = sizeRatio * (Math.log(sizes[i]) / Math.log(sizes[i-1]));
-            double actualTimeRatio = (double) times[i] / times[i-1];
-            
-            // Allow for some variance, but it shouldn't be quadratic growth
-            assertTrue(actualTimeRatio < expectedTimeRatio * 3, 
-                "Time complexity appears worse than O(n log n): " + actualTimeRatio + " vs expected " + expectedTimeRatio);
+            double expectedRatio = sizeRatio * (Math.log(sizes[i]) / Math.log(sizes[i-1]));
+            double actualRatio = (double) comparisons[i] / comparisons[i-1];
+
+            assertTrue(actualRatio < expectedRatio * 1.5,
+                "Comparison growth appears worse than O(n log n): " + actualRatio + " vs expected " + expectedRatio);
         }
     }
     
@@ -463,6 +476,44 @@ class TopRecordsAlgorithmTest {
         return records;
     }
     
+    /**
+     * Helper method to create Scorable objects that count how often their score is read.
+     * Scores are drawn from a fixed seed so the resulting comparison count is reproducible.
+     */
+    private List<CountingScorable> createCountingRecords(int count, long[] scoreReads) {
+        List<CountingScorable> records = new ArrayList<>();
+        Random random = new Random(42); // Fixed seed for reproducible results
+        for (int i = 0; i < count; i++) {
+            records.add(new CountingScorable(random.nextDouble() * count, scoreReads));
+        }
+        return records;
+    }
+
+    /**
+     * Scorable implementation that records every score read, allowing the number of
+     * comparator invocations to be measured deterministically.
+     */
+    private static class CountingScorable implements TopRecordsAlgorithm.Scorable {
+        private final double score;
+        private final long[] scoreReads;
+
+        public CountingScorable(double score, long[] scoreReads) {
+            this.score = score;
+            this.scoreReads = scoreReads;
+        }
+
+        @Override
+        public double getScore() {
+            scoreReads[0]++;
+            return score;
+        }
+
+        @Override
+        public String toString() {
+            return "CountingScorable{score=" + score + "}";
+        }
+    }
+
     /**
      * Mock implementation of Scorable for testing purposes.
      */

--- a/test_runner_demo.md
+++ b/test_runner_demo.md
@@ -24,7 +24,7 @@ This document demonstrates the testing setup and what the tests would verify whe
 
 ### 4. Performance Testing
 - ✅ Large dataset efficiency (1000 records)
-- ✅ O(n log n) time complexity verification
+- ✅ O(n log n) complexity verification by comparator-invocation count
 - ✅ Performance under 100ms for 1000 records
 
 ### 5. API Compatibility
@@ -41,7 +41,7 @@ mvn test
 
 ## Expected Results
 
-All 15 test methods should pass, demonstrating:
+All 24 test methods should pass (33 executions, as two are parameterized), demonstrating:
 - **Correctness**: Algorithm returns properly sorted top N records
 - **Robustness**: Handles all edge cases gracefully
 - **Performance**: Efficiently processes large datasets


### PR DESCRIPTION
## Summary

Three coupled test-infrastructure defects are fixed together, because fixing any one alone would leave the suite in a worse state than it is now.

- **`junit-vintage-engine` is added as a test-scoped dependency.** Nine of the twelve test classes are written against JUnit 4, but `junit-jupiter-engine` on the classpath causes Surefire to select the JUnit Platform provider, which only discovers JUnit 4 tests when the vintage engine is present. The suite goes from **47 tests to 125**; no production code change was required for the 78 newly-executed tests to pass.
- **`maven.test.failure.ignore` is removed from the `ci-test` profile.** GitHub Actions sets `CI=true`, so that profile activates on every `mvn --batch-mode clean verify` run in `build.yml`, and a failing unit test was reported but did not fail the job. The profile's optional-dependency overrides are left untouched, so its stated purpose is preserved. The opt-in `offline-test` profile is deliberately left as is.
- **The complexity assertion in `TopRecordsAlgorithmTest` is made deterministic.** Wall-clock ratios were being asserted, which measure JIT warm-up and GC rather than algorithmic complexity; the test was observed failing on `main` at the start of this session. Comparator invocations are now counted instead, via a `CountingScorable` whose `getScore()` increments a shared counter. This mattered for ordering: enabling fatal test failures while a flaky assertion remained would have made CI unreliable rather than trustworthy.

Ordering note: the flake fix is a prerequisite for the CI change, and the CI change is what gives the newly-enabled tests any value — hence one PR rather than three.

## Verification

Both directions were confirmed empirically rather than by reasoning.

**Flake fix (#81) — the assertion catches a quadratic implementation.** `Collections.sort` was temporarily replaced with a selection sort:

```
TopRecordsAlgorithmTest.testGetTopRecords_ComplexityValidation:411
  Comparison count suggests worse than O(n log n) for n=100: 4950 vs bound 664
```

Measured comparison counts for the real implementation are `533 / 3841 / 8699 / 19386` at n = `100 / 500 / 1000 / 2000` — roughly 85% of `n·log2(n)`. The absolute bound was therefore widened to `2·n·log2(n)` so that a future JDK sort implementation cannot cause a false failure, while a quadratic implementation (4950 at n=100 against a bound of 1329) is still caught decisively. A growth-ratio assertion is retained as a second, tighter check.

**Vintage engine (#80) and fatal failures (#84).** A temporary failing assertion was added to `LeaderboardEntryTest` (a JUnit 4 class) and `CI=true mvn -B test` was run against both states:

| State | Result |
|---|---|
| Before (this PR's `pom.xml` stashed) | `Tests run: 47, Failures: 0` — **BUILD SUCCESS**; the sentinel never executed |
| After | `Tests run: 126, Failures: 1` — **BUILD FAILURE** on `SENTINEL-JUNIT4-EXECUTED` |

The sentinel was reverted; `CI=true mvn -B -o clean test` on the committed tree reports `Tests run: 125, Failures: 0, Errors: 0, Skipped: 0`.

`help:active-profiles` was re-run under `CI=true` to confirm the `ci-test` profile still activates after the edit.

## Test plan

- [x] `mvn -B -o clean test` — 125 tests, green
- [x] `CI=true mvn -B -o clean test` — 125 tests, green (the profile that previously masked failures is now active *and* fatal)
- [x] Quadratic-implementation swap makes `testGetTopRecords_ComplexityValidation` fail; reverting restores green
- [x] Sentinel JUnit 4 failure fails the build after this change and did not before
- [x] `Simple CI` remains meaningful: `TopRecordsAlgorithm.java` itself is unmodified, so that workflow's standalone assertions still exercise the same code path

## Notes for the reviewer

- `pom.xml` is on this loop's do-not-auto-merge list, since dependency changes affect the shaded release artifact. The added dependency is test-scoped, so no change to the shipped JAR is expected, but the merge is left to a human.
- Two further wall-clock assertions remain in the same file (`duration < 100` for 1000 records, `duration < 500` for 5000). Their margins are roughly two orders of magnitude, so they were left alone rather than expanding this PR's scope; they are worth revisiting if they ever flake now that failures are fatal.
- `pom.xml` contains pre-existing duplicate declarations (`gson`, `slf4j-simple`, `junit`, `mockito-core` each declared twice, and `mockito.version` defined twice). These were left untouched to keep the diff scoped; a follow-up issue has been filed.
- Jacoco 0.8.8 cannot instrument class-file major version 65, so local runs on a JDK 21 host emit instrumentation warnings. CI builds on JDK 8 and is unaffected.

## Deferred this cycle

Every other open issue is deferred, with reasons: **#82** (CONTRIBUTING.md points at a non-existent `develop` branch) is unrelated to test infrastructure and is left for a docs-scoped cycle; **#47/#77** (Discord webhooks) is an in-flight draft PR being iterated between the repository owner and another agent, so it was not adopted or closed; **#54, #45, #43, #41, #40, #39** are feature work exceeding a polish-sized PR; **#13** is a question, not a work item.

Closes #80
Closes #81
Closes #84

<!-- gardener-tend-dispatch -->

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).