### PR TITLE
ci: publish a rolling dev prerelease from main

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,0 +1,90 @@
+name: Dev Release
+
+# Publishes a rolling prerelease of the main branch so that server operators can opt into
+# unreleased changes via Dan's Plugin Manager (`/dpm get activitytracker --experimental`).
+#
+# The build steps deliberately mirror release.yml — if the release build changes, change it here too.
+
+on:
+  push:
+    branches: [ main ]
+    # A documentation-only merge produces an identical JAR, so it is not worth a new prerelease
+    # (and the release notification it sends to every watcher of this repository).
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# The publish step deletes and recreates the release, so two runs must never overlap.
+# Queue instead of cancelling: a cancelled run could leave the repository with no dev release at all.
+concurrency:
+  group: dev-release
+  cancel-in-progress: false
+
+jobs:
+  dev-release:
+    runs-on: ubuntu-latest
+    # Forks have neither the release to publish to nor a reason to publish one.
+    if: github.repository == 'Dans-Plugins/Activity-Tracker'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Build with Maven
+        run: mvn clean package --batch-mode
+
+      - name: Republish the dev prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          # Dan's Plugin Manager installs the first .jar asset it finds on the release, so publishing
+          # more than one would leave the installed build depending on asset order. An empty or
+          # ambiguous match fails the run rather than publishing something unpredictable.
+          # release.yml publishes target/*.jar minus the shade plugin's original-*.jar; the same
+          # selection is made here, then asserted to be unambiguous.
+          jars=()
+          for jar in target/*.jar; do
+            case "$(basename "$jar")" in original-*) continue ;; esac
+            jars+=("$jar")
+          done
+          if [ ${#jars[@]} -ne 1 ]; then
+            echo "Expected exactly one JAR to publish, found ${#jars[@]}: ${jars[*]:-none}" >&2
+            exit 1
+          fi
+
+          # The dev tag has to move to the new commit. Editing a published release does not move its
+          # tag, so the release and its tag are deleted and recreated. This leaves a window of a few
+          # seconds with no dev release; a client that fetches during it sees "no experimental build
+          # published" and succeeds on the next attempt.
+          gh release delete dev --yes --cleanup-tag || true
+
+          gh release create dev \
+            --prerelease \
+            --target "$GITHUB_SHA" \
+            --title "Development build" \
+            --notes "Automated build of \`main\` at ${GITHUB_SHA}.
+
+          **This is not a release.** It is unreleased, unreviewed code that has not been through any
+          release check, and a broken build can stop a server from starting. Do not run it on a server
+          you care about without a backup.
+
+          Install it with Dan's Plugin Manager:
+
+          \`\`\`
+          /dpm get activitytracker --experimental
+          \`\`\`
+
+          Return to published releases with \`/dpm get activitytracker --stable\`." \
+            "${jars[0]}"


### PR DESCRIPTION
Part of the rollout behind Dan's Plugin Manager's experimental release channel. DPM can install main-branch builds with `/dpm get activitytracker --experimental`, which reads `releases/tags/dev` — this workflow publishes that release.

## Note on this repository specifically

Unlike the other plugins in this rollout, this repository has **no `release.yml`** whose build steps could be mirrored. The build was therefore run locally first, and `mvn clean package` was confirmed to succeed and leave exactly one publishable JAR in `target/` (the shade plugin's `original-*.jar` is excluded, as it is elsewhere in the organisation). The JDK is set to 8 to match the existing CI workflow.

## What it does

On every push to `main` that touches something other than documentation, the JAR is rebuilt and republished as a prerelease tagged `dev`. Because it is marked as a prerelease, GitHub's "latest release" is unaffected.

- **The release is deleted and recreated rather than edited.** Editing a published release does not move its tag to the new commit, and DPM derives each build's version identity from `target_commitish`. Recreating with `--target "$GITHUB_SHA"` is what makes `dev-<short sha>` change between builds; without it every build would look identical and DPM would report "already up to date" forever.
- **Exactly one JAR is asserted before publishing**, because DPM installs the first `.jar` asset it finds and two JARs would make the installed build depend on asset order.
- **Documentation-only merges are skipped**, and forks are excluded by a repository guard.

## Verification

The same workflow is already merged and confirmed working end to end on Medieval-Factions, AlternateAccountFinder, Currencies, FoodSpoilage, Herald and Dans-Essentials: each published release returns a 40-character commit sha in `target_commitish`, DPM's parser turns it into `dev-<short sha>`, the JAR downloads anonymously over HTTP 200, and `releases/latest` still returns the real release.

No CHANGELOG entry is included because this repository does not keep a `CHANGELOG.md`.

---

_drafted by Claude on behalf of Daniel Stephenson_
