### PR TITLE
Correct contributor branch guidance and document missing REST API error responses

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,18 +38,18 @@ Issues are grouped into [milestones](https://github.com/Dans-Plugins/Activity-Tr
 ## Making Changes
 
 1. Make sure an issue exists for the work. If not, create one.
-2. Switch to `develop`: `git checkout develop`
+2. Switch to `main`: `git checkout main`
 3. Create a branch: `git checkout -b <branch-name>`
 4. Make your changes.
 5. Test your changes.
 6. Commit: `git commit -m "Description of changes"`
 7. Push: `git push origin <branch-name>`
-8. Open a pull request against `develop`, link the related issue with `#<number>`.
+8. Open a pull request against `main`, link the related issue with `#<number>`.
 9. Address review feedback.
 
-### Language Files
+### Command Output
 
-Update `src/main/resources/lang/` for any user-facing string changes.
+User-facing strings are written directly in the command classes under `src/main/java/dansplugins/activitytracker/commands/`. Follow [COMMAND_OUTPUT_STYLE.md](COMMAND_OUTPUT_STYLE.md) when adding or changing any of them, so output stays consistent across commands.
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Issues are grouped into [milestones](https://github.com/Dans-Plugins/Activity-Tr
 
 ### Command Output
 
-User-facing strings are written directly in the command classes under `src/main/java/dansplugins/activitytracker/commands/`. Follow [COMMAND_OUTPUT_STYLE.md](COMMAND_OUTPUT_STYLE.md) when adding or changing any of them, so output stays consistent across commands.
+User-facing strings are written directly in the classes that send them — mostly the command classes under `src/main/java/dansplugins/activitytracker/commands/`, and also `ActivityRecord`, `ActivityRecordService` and `ConfigService`. Follow [COMMAND_OUTPUT_STYLE.md](COMMAND_OUTPUT_STYLE.md) when adding or changing any of them, so output stays consistent across commands.
 
 ## Testing
 

--- a/REST_API.md
+++ b/REST_API.md
@@ -163,7 +163,7 @@ Get average daily activity for a specific player over a specified period.
 }
 ```
 
-### Unknown Endpoints
+## Unknown Endpoints
 
 Any request to a path that is not listed above is answered with a 404 and a JSON body:
 

--- a/REST_API.md
+++ b/REST_API.md
@@ -104,6 +104,13 @@ Get detailed activity information for a specific player.
 }
 ```
 
+**Error Response (400):**
+```json
+{
+  "error": "Invalid UUID format"
+}
+```
+
 **Error Response (404):**
 ```json
 {
@@ -139,10 +146,30 @@ Get average daily activity for a specific player over a specified period.
 }
 ```
 
-**Error Response (400):**
+**Error Responses (400):**
+```json
+{
+  "error": "Invalid UUID format"
+}
+```
 ```json
 {
   "error": "Days must be a positive number"
+}
+```
+```json
+{
+  "error": "Invalid days parameter"
+}
+```
+
+### Unknown Endpoints
+
+Any request to a path that is not listed above is answered with a 404 and a JSON body:
+
+```json
+{
+  "error": "Endpoint not found"
 }
 ```
 


### PR DESCRIPTION
## Summary

A documentation accuracy sweep was performed across `README.md`, `CONTRIBUTING.md`, `USER_GUIDE.md`, `COMMANDS.md`, `CONFIG.md`, `REST_API.md`, `openapi.yaml`, `CHANGELOG.md` and `test_runner_demo.md`, with every claim checked against the source it describes. Two documents were found to be inaccurate and are corrected here.

**`CONTRIBUTING.md`**
- Contributors were told to switch to and open pull requests against `develop`. `git ls-remote --heads origin` shows only `main` and `copilot/add-discord-webhook-messages`, and the default branch is `main`. Both references now name `main`.
- The "Language Files" section instructed contributors to update `src/main/resources/lang/`. That directory does not exist — `src/main/resources` contains only `plugin.yml`, and no language-file loading exists anywhere in `src/main/java`. The section is replaced with one describing where user-facing strings actually live (the command classes) and pointing at `COMMAND_OUTPUT_STYLE.md`, which no other document previously linked to.

**`REST_API.md`**
- The `400 Invalid UUID format` response returned by `GET /api/players/{uuid}` was undocumented, although `openapi.yaml` declares it.
- Of the three 400 responses returned by `GET /api/average-daily-activity/{uuid}`, only `Days must be a positive number` was documented; `Invalid UUID format` and `Invalid days parameter` are now listed alongside it.
- The `404 Endpoint not found` body returned by `Spark.notFound` for unrecognised paths was undocumented and is now described.

No source file is modified by this PR.

## Findings filed rather than fixed here

Three further findings from the sweep are source or protected-path changes and were filed instead of being folded into a documentation PR:

- #90 — `openapi.yaml` declares `info.version: 1.2.0`, predating the `1.3.0` release that introduced the REST API. `openapi.yaml` is a protected path warranting human review.
- #91 — `plugin.yml` does not declare the `at.default` node that `DefaultCommand` and `COMMANDS.md` both name.
- #92 — three wall-clock assertions remain in `TopRecordsAlgorithmTest` after #81, the test-suite counterpart of #86.

Claims checked and found accurate, so left untouched: every `openapi.yaml` path, method and response schema against `RestApiService`; every `CONFIG.md` option against `ConfigService.saveMissingConfigDefaultsIfNotPresent`; every `COMMANDS.md` entry against its command class (including the 1–100 bound on `/at top` and the ten-session cap in `/at list`); the `USER_GUIDE.md` permission table against `plugin.yml`; the Java 8 and API 1.13 claims against `pom.xml` and `plugin.yml`; and `test_runner_demo.md`'s "24 test methods, 33 executions" count, which matches the 22 `@Test` plus 2 parameterised methods in `TopRecordsAlgorithmTest` and the 33 executions reported by Surefire.

## Deferred backlog

Every other open issue was left untouched this cycle so that the sweep stayed within one coherent, documentation-only diff: #87 and #86 both modify protected paths (`pom.xml`, `.github/workflows/simple-ci.yml`) and are expected to be reviewed by a human; #54 and #39–#45 are feature work larger than a polish-sized PR; #43 is an epic; #47 is already covered by draft PR #77; and #13 is a question rather than a work item. Issue #82's suggestion to trim `develop` from the workflow branch triggers was also deferred for the protected-path reason — `.github/workflows/build.yml` and `.github/workflows/simple-ci.yml` still list it, which is harmless because no such branch exists.

## Test plan

- [x] `mvn test` — 125 tests, 0 failures (documentation-only change; run as a regression guard)
- [x] Every corrected claim re-checked against the file it describes
- [x] `git diff --stat origin/main` — 2 files, 32 insertions, 5 deletions, well inside the scope ceiling

Closes #82

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->

---

_drafted by Claude on behalf of Daniel Stephenson_